### PR TITLE
Enable NoENOBUFS option to drop events instead of erroring out

### DIFF
--- a/garlic.go
+++ b/garlic.go
@@ -130,6 +130,10 @@ func dialPCN() (CnConn, error) {
 		return CnConn{}, fmt.Errorf("Error in netlink: %s", err)
 	}
 
+	// Enable NoENOBUFS option so that packets will be dropped instead of
+	// returning an error that will terminate the program.
+	c.SetOption(netlink.NoENOBUFS, true)
+
 	//setup process connector hdr
 	cbHdr := cbID{Idx: CnIdxProc, Val: CnValProc}
 	var connBody uint32 = ProcCnMcastListen


### PR DESCRIPTION
The problem can be reproduced by sending `SIGSTOP` to your program, starting many
processes (e.g. using `find /etc -exec ls -l '{}' \;`), then sending `SIGCONT`.

Before this commit, the program would exit due to the `ENOBUFS` error.
After this commit, the program receives as many events as it can.